### PR TITLE
Fixing rate_limit_error & slightly changing text for Issue #2 and PR #4

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,9 +3,9 @@ import requests
 import re
 
 from pythorhead import Lemmy
-from . import credentials
-from . import vars
-from time import sleep
+import credentials
+import vars
+import time
 
 copy_automoderator_posts = False
 
@@ -30,7 +30,7 @@ if __name__ == '__main__':
 
     # Get the subreddit object
     reddit = get_reddit()
-    subreddit = reddit.subreddit(subreddit_name)
+    subreddit = reddit.subreddit(vars.subreddit_name)
 
     # Get the lemmy object
     lemmy = get_lemmy()
@@ -38,6 +38,7 @@ if __name__ == '__main__':
 
     # Watch subreddit for new posts
     for submission in subreddit.stream.submissions():
+        time.sleep(60)
         print(f"New post found: {submission.title} ({submission.url})")
 
         author_name = submission.author.name
@@ -46,7 +47,7 @@ if __name__ == '__main__':
             print("Not copying automoderator content")
             continue
 
-        title = f"[reddit user {author_name}] - {submission.title}"
+        title = f"[X-Posted from Reddit - /u/{author_name}] - {submission.title}"
         if submission.is_video:
             print("Saving video...")
             media_url = submission.media['reddit_video']['fallback_url']
@@ -73,4 +74,3 @@ if __name__ == '__main__':
 
         print("Uploading to lemmy...")
         lemmy.post.create(community_id=community_id, name=title, url=media_url, body=media_content)
-        sleep(10)  # flooding is bad and likely to get you banned


### PR DESCRIPTION
Included are my original changes to get the bot to work on Arch Linux due to the issues with importing credentials and vars which is Issue #1, as well as changes to get the sleep() to work properly to fix Issue #5 and a slight change to the text in post titles for Issue #2 and PR #4.

I had to move the sleep command as the first command in the for loop to get it sleep properly, and due to something on the lemmy.ca instance, even a 10, 20, or 30 second sleep often resulted in rate_limit_error problems even after the sleep was functioning properly, where changing it to sleep(60) solved this issue.